### PR TITLE
[perf] : 댓글 좋아요 상태 확인 로직 Map 기반으로 최적화

### DIFF
--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/service/CommentService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/service/CommentService.java
@@ -21,7 +21,9 @@ import com.golden_dobakhe.HakPle.global.Status;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -74,18 +76,20 @@ public class CommentService {
 
         List<CommentLike> likes = likeRepository.findByCommentIdInAndUserId(commentIds, userId);
 
-        Set<Long> likedCommentIds = likes.stream()
+        Map<Long, Boolean> likedMap = likes.stream()
                 .map(like -> like.getComment().getId())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        id -> true
+                ));
 
         List<CommentResponseDto> result = comments.stream()
                 .map(comment -> {
-                    boolean isLiked = likedCommentIds.contains(comment.getId());
-
-                    CommentResponseDto dto = CommentResponseDto.fromEntity(comment, isLiked);
-                    return dto;
+                    boolean isLiked = likedMap.getOrDefault(comment.getId(), false);
+                    return CommentResponseDto.fromEntity(comment, isLiked);
                 })
-                .collect(Collectors.toList());
+                .toList();
+
 
         return result;
     }


### PR DESCRIPTION

### 🔧 작업 개요
- 댓글 목록 조회 시 좋아요 여부 확인 로직을 `Set.contains()` 방식에서 `Map.getOrDefault()` 방식으로 개선
- 성능 향상 및 가독성 개선 목적

---

### ✅ 주요 변경사항
- `CommentService.getCommentsByBoardId(boardId, userId)` 내부 로직 최적화
- 좋아요 여부를 `Map<Long, Boolean>` 구조로 처리하여 반복 탐색 제거
- `likedMap.getOrDefault(commentId, false)`로 좋아요 상태 확인

---

### 💡 기대 효과
- 댓글 수가 많아질수록 성능 향상
- 코드 간결성 및 유지보수성 향상

---

### ✅ 테스트 항목
- [x] 로그인한 사용자가 댓글 목록 조회 시 좋아요 여부 정확히 반환되는지 확인
- [x] 좋아요를 누르지 않은 댓글은 `false`로 처리되는지 확인
- [x] 기존 기능들과 충돌 없이 작동



)
